### PR TITLE
Temporary workaround update value-acessor-base.ts

### DIFF
--- a/src/app/commons/value-acessor-base.ts
+++ b/src/app/commons/value-acessor-base.ts
@@ -3,7 +3,7 @@ import { Input } from '@angular/core';
 
 const vanillaMasker = require('vanilla-masker');
 
-export abstract class ValueAccessorBase<T> implements ControlValueAccessor {
+export abstract class ValueAccessorBase<T=unknown> implements ControlValueAccessor {
 
   @Input()
   public disabled: boolean = false;


### PR DESCRIPTION
Temporary workaround update of value-acessor-base.ts for fix Ivy compiler problem:

```
ERROR in node_modules/@nbfontana/ngx-br/src/app/commons/value-acessor-base.d.ts:18:40 - error TS2314: Generic type 'ValueAccessorBase<T>' requires 1 type argument(s).

static ngBaseDef: ɵngcc0.ɵɵBaseDef<ValueAccessorBase>;
```

Workaround solution: https://github.com/angular/angular/issues/31160#issuecomment-535648669

## Proposed Changes

  - Insert a default type for the generic type parameter
